### PR TITLE
fix for react routing

### DIFF
--- a/airportmgr/frontend/src/components/App.js
+++ b/airportmgr/frontend/src/components/App.js
@@ -13,8 +13,8 @@ export default class App extends Component {
     return (
     <div>
       <HomePage />
-      <AirlineEmployeePage />
-      <AirportEmployeePage />
+      {/* <AirlineEmployeePage />
+      <AirportEmployeePage /> */}
     </div>
     );
   }

--- a/airportmgr/frontend/src/components/HomePage.js
+++ b/airportmgr/frontend/src/components/HomePage.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import AirlineEmployeePage from "./AirlineEmployeePage";
 import AirportEmployeePage from "./AirportEmployeePage";
 import {BrowserRouter as Router, 
-        Switch, 
+        Routes, 
         Route, 
         Link, 
         Redirect} from "react-router-dom";
@@ -16,13 +16,11 @@ export default class HomePage extends Component {
     return (
       // <p>This is the Home page.</p>
       <Router>
-        <Switch>
-          <Route exact path = "/">
-            <p>This is the home page</p>
-          </Route>
-          <Route path = "/airlineemployeepage" component= {AirlineEmployeePage}></Route>
-          <Route path = "/airportemployeepage" component= {AirportEmployeePage}></Route>
-        </Switch>
+        <Routes>
+          <Route exact path = "/" element={<p>This is the home page</p>} />
+          <Route path = "/airlineemployeepage" element={<AirlineEmployeePage />} />
+          <Route path = "/airportemployeepage" element={<AirportEmployeePage />} />
+        </Routes>
       </Router>
     );
   }

--- a/airportmgr/frontend/templates/frontend/index.html
+++ b/airportmgr/frontend/templates/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Music Controller</title>
+    <title>Airport Manager</title>
     {% load static %}
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <link


### PR DESCRIPTION
Earlier going to path "/" was showing all 3 pages, so fixed this so that path "/" shows the home page content, path "/airlineemployeepage" shows airline employee page content and path "/airportemployeepage" shows airport employee page content.
Also fixed page title.

![Screenshot (105)](https://user-images.githubusercontent.com/113153528/205152997-9e869a6f-544a-4e95-90d5-5f610d3eb1f6.png)
![Screenshot (103)](https://user-images.githubusercontent.com/113153528/205153014-2ee45ebf-1ca4-4fc4-909c-ae79b8b4640e.png)
![Screenshot (104)](https://user-images.githubusercontent.com/113153528/205153020-e5b80a87-569e-4c77-bf00-b7dc044e4c08.png)
